### PR TITLE
Update Homebrew packages

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 
-VERSION=1.4.0
+VERSION=1.5.0
 
 # ------------------------------------------------------------------------------
-# UpClean v1.4.0 (https://upclean.app) — An update and cleanup script for macOS.
+# UpClean v1.5.0 (https://upclean.app) — An update and cleanup script for macOS.
 # ------------------------------------------------------------------------------
 
 green="\033[0;32m"

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,7 @@ Options:
       --skip-dns                 Skip flushing DNS cache
       --skip-docker              Skip cleaning Docker
       --skip-homebrew            Skip updating Homebrew
+      --skip-homebrew-packages   Skip updating Homebrew packages
       --skip-mas                 Skip updating Mac App Store applications
       --skip-memory              Skip clearing inactive memory
       --skip-update              Skip updating

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ mv upclean /usr/local/bin/upclean
 ```
 $ upclean --help
 
-UpClean 1.4.0 🧼 upclean.app
+UpClean 1.5.0 🧼 upclean.app
 
 An update and cleanup script for macOS.
 

--- a/upclean.sh
+++ b/upclean.sh
@@ -25,6 +25,7 @@ shouldUpdate=true
 shouldUpdateComposer=true
 shouldUpdateComposerPackages=true
 shouldUpdateHomebrew=true
+shouldUpdateHomebrewPackages=true
 shouldUpdateMas=true
 
 # ------------------------------------------------------------------------------
@@ -41,6 +42,7 @@ function usage() {
     printf -- "%b      --skip-dns                 %bSkip flushing DNS cache\n" "$green" "$reset"
     printf -- "%b      --skip-docker              %bSkip cleaning Docker\n" "$green" "$reset"
     printf -- "%b      --skip-homebrew            %bSkip updating Homebrew\n" "$green" "$reset"
+    printf -- "%b      --skip-homebrew-packages   %bSkip updating Homebrew packages\n" "$green" "$reset"
     printf -- "%b      --skip-mas                 %bSkip updating Mac App Store applications\n" "$green" "$reset"
     printf -- "%b      --skip-memory              %bSkip clearing inactive memory\n" "$green" "$reset"
     printf -- "%b      --skip-update              %bSkip updating\n" "$green" "$reset"
@@ -321,6 +323,19 @@ function updateHomebrew() {
     fi
 }
 
+function updateHomebrewPackages() {
+    if type "brew" &>/dev/null; then
+        outdatedPackages=$(brew outdated | awk '{ print $1 }')
+        if [[ -n $outdatedPackages ]]; then
+            info "update" "Homebrew packages"
+            for package in $outdatedPackages; do
+                brew upgrade "$package" &>/dev/null
+            done
+            info "done"
+        fi
+    fi
+}
+
 function updateMacAppStore() {
     if type "mas" &>/dev/null && [[ -n $(mas outdated) ]]; then
         info "update" "Mac App Store"
@@ -385,6 +400,7 @@ function initializeUpdate() {
     $shouldUpdateComposer && updateComposer
     $shouldUpdateComposerPackages && updateComposerPackages
     $shouldUpdateHomebrew && updateHomebrew
+    $shouldUpdateHomebrewPackages && updateHomebrewPackages
     $shouldUpdateMas && updateMacAppStore
 }
 
@@ -402,6 +418,7 @@ function checkOptions() {
             "--skip-dns") shouldFlushDns=false ;;
             "--skip-docker") shouldCleanDocker=false ;;
             "--skip-homebrew") shouldUpdateHomebrew=false ;;
+            "--skip-homebrew-packages") shouldUpdateHomebrewPackages=false ;;
             "--skip-mas") shouldUpdateMas=false ;;
             "--skip-memory") shouldClearMemory=false ;;
             "--skip-update") shouldUpdate=false ;;

--- a/upclean.sh
+++ b/upclean.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-VERSION=1.4.0
+VERSION=1.5.0
 
 # ------------------------------------------------------------------------------
-# UpClean v1.4.0 (https://upclean.app) — An update and cleanup script for macOS.
+# UpClean v1.5.0 (https://upclean.app) — An update and cleanup script for macOS.
 # ------------------------------------------------------------------------------
 
 soap=🧼


### PR DESCRIPTION
Automatically update outdated Homebrew packages.

Feature can be disabled by adding `--skip-homebrew-packages` to `~/.upcleanrc`.