### PR TITLE
Include outdated casks when updating Homebrew packages

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
 
-VERSION=1.5.0
+VERSION=1.6.0
 
 # ------------------------------------------------------------------------------
-# UpClean v1.5.0 (https://upclean.app) — An update and cleanup script for macOS.
+# UpClean v1.6.0 (https://upclean.app) — An update and cleanup script for macOS.
 # ------------------------------------------------------------------------------
 
 green="\033[0;32m"

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ mv upclean /usr/local/bin/upclean
 ```
 $ upclean --help
 
-UpClean 1.5.0 🧼 upclean.app
+UpClean 1.6.0 🧼 upclean.app
 
 An update and cleanup script for macOS.
 

--- a/upclean.sh
+++ b/upclean.sh
@@ -325,7 +325,7 @@ function updateHomebrew() {
 
 function updateHomebrewPackages() {
     if type "brew" &>/dev/null; then
-        outdatedPackages=$(brew outdated | awk '{ print $1 }')
+        outdatedPackages=$(brew outdated --greedy | awk '{ print $1 }')
         if [[ -n $outdatedPackages ]]; then
             info "update" "Homebrew packages"
             for package in $outdatedPackages; do

--- a/upclean.sh
+++ b/upclean.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-VERSION=1.5.0
+VERSION=1.6.0
 
 # ------------------------------------------------------------------------------
-# UpClean v1.5.0 (https://upclean.app) — An update and cleanup script for macOS.
+# UpClean v1.6.0 (https://upclean.app) — An update and cleanup script for macOS.
 # ------------------------------------------------------------------------------
 
 soap=🧼


### PR DESCRIPTION
Added `--greedy` flag to `brew outdated` command to ensure outdated casks are included and updated.